### PR TITLE
Remove the call to init

### DIFF
--- a/include/ionic/ionic.h
+++ b/include/ionic/ionic.h
@@ -72,7 +72,6 @@ class Table {
     friend class IonicTest;
 public:
     static bool colorEnabled;
-    static void initConsole();
 
     Table(const TableOptions& options = TableOptions()) : _options(options) {}
 
@@ -115,6 +114,8 @@ public:
     static std::string colorize(Color c, const std::string& s);
 
 private:
+    static void initConsole();
+
     // Remove CR.
     static void normalizeNL(std::string& s) {
         s.erase(std::remove(s.begin(), s.end(), '\r'), s.end());

--- a/readme.md
+++ b/readme.md
@@ -59,17 +59,6 @@ Main is kept stable with automated tests.
 
 ## Usage
 
-### Setup
-
-Only once, before output. Call:
-
-```c++
-        ionic::Table::initConsole();
-```
-
-Windows 10 terminals can be grumpy about output in color, and this enables it
-for the current terminal.
-
 ### Creating Tables
 
 1. Construct a Table with TableOptions. (See TableOptions for features that can be set.)

--- a/src/ionic.cpp
+++ b/src/ionic.cpp
@@ -31,6 +31,9 @@ void Table::initConsole()
 	static std::atomic<bool> init = false;
 	if (!init.exchange(true)) {
 #ifdef _WIN32
+		// Win10 setup code, and I did need it there. Now...I have no
+		// Win10 machine and nothing to test this one, so it's questionable
+		// whether I should keep it.
 		HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
 		DWORD oldMode = 0;
 		GetConsoleMode(handle, &oldMode);

--- a/src/ionic.cpp
+++ b/src/ionic.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <numeric>
 #include <iostream>
+#include <atomic>
 
 #if defined(_WIN32)
 #	define WIN32_LEAN_AND_MEAN
@@ -27,17 +28,21 @@ bool Table::colorEnabled = true;
 
 void Table::initConsole()
 {
+	static std::atomic<bool> init = false;
+	if (!init.exchange(true)) {
 #ifdef _WIN32
-	HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
-	DWORD oldMode = 0;
-	GetConsoleMode(handle, &oldMode);
-	DWORD mode = oldMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-	SetConsoleMode(handle, mode);
+		HANDLE handle = GetStdHandle(STD_OUTPUT_HANDLE);
+		DWORD oldMode = 0;
+		GetConsoleMode(handle, &oldMode);
+		DWORD mode = oldMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+		SetConsoleMode(handle, mode);
 #endif
+	}
 }
 
 int Table::consoleWidth() 
 {
+	initConsole();
 #if defined(_WIN32)
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
@@ -365,6 +370,7 @@ std::vector<int> Table::computeWidths(const int w) const
 
 void Table::print() const
 {
+	initConsole();
 	std::cout << format();
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -273,7 +273,6 @@ int main(int argc, const char* argv[])
 			printAllTests = true;
     }
 
-    ionic::Table::initConsole();
     bool okay = ionic::IonicTest::test();
     if (okay)
         std::cout << "All tests passed.\n";


### PR DESCRIPTION
It can be called on demand easily. (And does nothing anywhere except win10)